### PR TITLE
Fix the package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.1.0',
     author='Jochem Oosterveen',
     author_email='jochem@oosterveen.net',
-    packages=['EPP'],
+    packages=['epp'],
     description='Python EPP client',
     long_description=(
         "Python-EPP provides an interface to the Extensible Provisioning "


### PR DESCRIPTION
Installation (under *nix) fails because the name of the package specified in `setup.py` is in wrong case.

```
error: package directory 'EPP' does not exist
```

Changing the package name from `EPP` to `epp` fixes the issue.
